### PR TITLE
Implement minimal FastAPI admin panel

### DIFF
--- a/app/admin_panel.py
+++ b/app/admin_panel.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi.templating import Jinja2Templates
+from passlib.context import CryptContext
+from pydantic import BaseModel, EmailStr, ValidationError, constr
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.backend.db_depends import get_db
+from app.models.user import User
+
+ADMIN_USERNAME = "admin"
+ADMIN_PASSWORD = "secret"
+SESSION_COOKIE_NAME = "admin_session"
+SESSION_TOKEN = "basic-admin-session"
+
+_templates_dir = Path(__file__).resolve().parent / "templates"
+templates = Jinja2Templates(directory=str(_templates_dir))
+
+router = APIRouter(prefix="/admin", tags=["Admin"], include_in_schema=False)
+
+strict_basic = HTTPBasic()
+optional_basic = HTTPBasic(auto_error=False)
+password_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class UserBase(BaseModel):
+    first_name: constr(strip_whitespace=True, min_length=1, max_length=50)
+    last_name: constr(strip_whitespace=True, min_length=1, max_length=50)
+    username: constr(strip_whitespace=True, min_length=3, max_length=50)
+    email: EmailStr
+    is_active: bool = True
+    is_admin: bool = False
+    is_supplier: bool = False
+    is_customer: bool = True
+
+    class Config:
+        orm_mode = True
+
+
+class UserCreate(UserBase):
+    password: constr(min_length=6, max_length=128)
+
+
+class UserUpdate(UserBase):
+    password: constr(min_length=6, max_length=128) | None = None
+
+
+@dataclass
+class AdminAuth:
+    method: str
+
+
+def _credentials_valid(credentials: HTTPBasicCredentials) -> bool:
+    correct_username = secrets.compare_digest(credentials.username, ADMIN_USERNAME)
+    correct_password = secrets.compare_digest(credentials.password, ADMIN_PASSWORD)
+    return correct_username and correct_password
+
+
+def _checkbox_to_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.lower() == "true"
+
+
+def _to_namespace(data: dict[str, Any]) -> SimpleNamespace:
+    return SimpleNamespace(**data)
+
+
+def _humanize_errors(error: ValidationError) -> list[str]:
+    messages: list[str] = []
+    for item in error.errors():
+        location = " → ".join(str(part) for part in item["loc"])
+        messages.append(f"{location}: {item['msg']}")
+    return messages
+
+
+async def _fetch_users(db: AsyncSession) -> list[User]:
+    result = await db.execute(select(User).order_by(User.id))
+    return result.scalars().all()
+
+
+async def _render_users_page(
+    *,
+    request: Request,
+    db: AsyncSession,
+    errors: list[str] | None = None,
+    message: str | None = None,
+    form_data: SimpleNamespace | None = None,
+    status_code: int = status.HTTP_200_OK,
+) -> HTMLResponse:
+    users = await _fetch_users(db)
+    context = {
+        "request": request,
+        "users": users,
+        "errors": errors or [],
+        "message": message,
+        "form_data": form_data,
+    }
+    return templates.TemplateResponse("admin/users.html", context, status_code=status_code)
+
+
+def require_basic_login(
+    credentials: HTTPBasicCredentials = Depends(strict_basic),
+) -> AdminAuth:
+    if not _credentials_valid(credentials):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Неверные учётные данные администратора.",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return AdminAuth(method="basic")
+
+
+def ensure_admin(
+    request: Request,
+    credentials: HTTPBasicCredentials | None = Depends(optional_basic),
+) -> AdminAuth:
+    if credentials is not None:
+        if not _credentials_valid(credentials):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Неверные учётные данные администратора.",
+                headers={"WWW-Authenticate": "Basic"},
+            )
+        return AdminAuth(method="basic")
+
+    cookie_token = request.cookies.get(SESSION_COOKIE_NAME)
+    if cookie_token == SESSION_TOKEN:
+        return AdminAuth(method="cookie")
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Требуется авторизация администратора.",
+        headers={"WWW-Authenticate": "Basic"},
+    )
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request) -> HTMLResponse:
+    context = {"request": request, "errors": [], "message": None}
+    return templates.TemplateResponse("admin/login.html", context)
+
+
+@router.post("/login")
+async def login(_: AdminAuth = Depends(require_basic_login)) -> JSONResponse:
+    response = JSONResponse({"detail": "ok"})
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        SESSION_TOKEN,
+        httponly=True,
+        samesite="lax",
+        max_age=3600,
+    )
+    return response
+
+
+@router.get("/users", response_class=HTMLResponse)
+async def list_users(
+    request: Request,
+    _: AdminAuth = Depends(ensure_admin),
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    message = request.query_params.get("message")
+    return await _render_users_page(request=request, db=db, message=message)
+
+
+@router.post("/users")
+async def create_user(
+    request: Request,
+    _: AdminAuth = Depends(ensure_admin),
+    db: AsyncSession = Depends(get_db),
+    first_name: str = Form(...),
+    last_name: str = Form(...),
+    username: str = Form(...),
+    email: str = Form(...),
+    password: str = Form(...),
+    is_active: str | None = Form(None),
+    is_admin: str | None = Form(None),
+    is_supplier: str | None = Form(None),
+    is_customer: str | None = Form(None),
+):
+    form_values = {
+        "first_name": first_name,
+        "last_name": last_name,
+        "username": username,
+        "email": email,
+        "password": password,
+        "is_active": _checkbox_to_bool(is_active, default=True),
+        "is_admin": _checkbox_to_bool(is_admin),
+        "is_supplier": _checkbox_to_bool(is_supplier),
+        "is_customer": _checkbox_to_bool(is_customer, default=True),
+    }
+
+    try:
+        payload = UserCreate(**form_values)
+    except ValidationError as exc:
+        safe_values = form_values.copy()
+        safe_values.pop("password", None)
+        return await _render_users_page(
+            request=request,
+            db=db,
+            errors=_humanize_errors(exc),
+            form_data=_to_namespace(safe_values),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    user = User(
+        first_name=payload.first_name,
+        last_name=payload.last_name,
+        username=payload.username,
+        email=payload.email,
+        hashed_password=password_context.hash(payload.password),
+        is_active=payload.is_active,
+        is_admin=payload.is_admin,
+        is_supplier=payload.is_supplier,
+        is_customer=payload.is_customer,
+    )
+    db.add(user)
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        safe_values = form_values.copy()
+        safe_values.pop("password", None)
+        return await _render_users_page(
+            request=request,
+            db=db,
+            errors=["Логин или email уже используются."],
+            form_data=_to_namespace(safe_values),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return RedirectResponse(
+        url="/admin/users?message=Пользователь создан",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@router.get("/users/{user_id}/edit", response_class=HTMLResponse)
+async def edit_user(
+    request: Request,
+    user_id: int,
+    _: AdminAuth = Depends(ensure_admin),
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    user = await db.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Пользователь не найден.")
+
+    context = {
+        "request": request,
+        "user": user,
+        "errors": [],
+        "message": None,
+        "form_data": None,
+    }
+    return templates.TemplateResponse("admin/user_form.html", context)
+
+
+@router.post("/users/{user_id}")
+async def update_user(
+    request: Request,
+    user_id: int,
+    _: AdminAuth = Depends(ensure_admin),
+    db: AsyncSession = Depends(get_db),
+    first_name: str = Form(...),
+    last_name: str = Form(...),
+    username: str = Form(...),
+    email: str = Form(...),
+    password: str | None = Form(None),
+    is_active: str | None = Form(None),
+    is_admin: str | None = Form(None),
+    is_supplier: str | None = Form(None),
+    is_customer: str | None = Form(None),
+):
+    user = await db.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Пользователь не найден.")
+
+    cleaned_password = password or None
+
+    form_values = {
+        "first_name": first_name,
+        "last_name": last_name,
+        "username": username,
+        "email": email,
+        "password": cleaned_password,
+        "is_active": _checkbox_to_bool(is_active),
+        "is_admin": _checkbox_to_bool(is_admin),
+        "is_supplier": _checkbox_to_bool(is_supplier),
+        "is_customer": _checkbox_to_bool(is_customer),
+    }
+
+    try:
+        payload = UserUpdate(**form_values)
+    except ValidationError as exc:
+        context = {
+            "request": request,
+            "user": user,
+            "errors": _humanize_errors(exc),
+            "message": None,
+            "form_data": _to_namespace({
+                key: value for key, value in form_values.items() if key != "password"
+            }),
+        }
+        return templates.TemplateResponse(
+            "admin/user_form.html",
+            context,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    user.first_name = payload.first_name
+    user.last_name = payload.last_name
+    user.username = payload.username
+    user.email = payload.email
+    user.is_active = payload.is_active
+    user.is_admin = payload.is_admin
+    user.is_supplier = payload.is_supplier
+    user.is_customer = payload.is_customer
+
+    if payload.password:
+        user.hashed_password = password_context.hash(payload.password)
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        context = {
+            "request": request,
+            "user": user,
+            "errors": ["Логин или email уже используются."],
+            "message": None,
+            "form_data": _to_namespace({
+                key: value for key, value in form_values.items() if key != "password"
+            }),
+        }
+        return templates.TemplateResponse(
+            "admin/user_form.html",
+            context,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return RedirectResponse(
+        url="/admin/users?message=Изменения сохранены",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@router.post("/users/{user_id}/delete")
+async def delete_user(
+    user_id: int,
+    _: AdminAuth = Depends(ensure_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    user = await db.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Пользователь не найден.")
+
+    await db.delete(user)
+    await db.commit()
+
+    return RedirectResponse(
+        url="/admin/users?message=Пользователь удалён",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -4,8 +4,8 @@ from fastapi.templating import Jinja2Templates
 from starlette.websockets import WebSocketDisconnect
 from celery import Celery
 import os
-from fastadmin import fastapi_app as admin_app
 
+from app.admin_panel import router as admin_router
 from app.connection_manager import ConnectionManager
 from app.logging_config import configure_logging, log_middleware
 from app.main_routers import setup_routers
@@ -39,8 +39,8 @@ app = FastAPI(
 )
 
 
-# регистрация приложения админки
-app.mount("/admin", admin_app)
+# регистрация маршрутов админ-панели
+app.include_router(admin_router)
 
 
 # Создаем экземпляр Celery

--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Админ-панель{% endblock %}</title>
+  <style>
+    :root {
+      color-scheme: light;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+      margin: 0;
+      background: #f5f7fb;
+      color: #1f2937;
+    }
+    header {
+      background: #111827;
+      color: #fff;
+      padding: 1rem 2rem;
+    }
+    nav {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+    nav a {
+      color: inherit;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    nav a:hover {
+      text-decoration: underline;
+    }
+    main {
+      max-width: 960px;
+      margin: 2rem auto;
+      padding: 0 1.5rem 3rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 0.75rem;
+      padding: 1.75rem;
+      box-shadow: 0 16px 30px -20px rgba(15, 23, 42, 0.65);
+      margin-bottom: 1.75rem;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      border: 1px solid #d1d5db;
+      padding: 0.75rem 0.85rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: #f3f4f6;
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      font-weight: 600;
+      border-radius: 0.6rem;
+      border: none;
+      padding: 0.55rem 1.1rem;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .button.primary {
+      background: #2563eb;
+      color: #fff;
+    }
+    .button.secondary {
+      background: #e5e7eb;
+      color: #1f2937;
+    }
+    .button.danger {
+      background: #dc2626;
+      color: #fff;
+    }
+    .button.link {
+      background: transparent;
+      color: #2563eb;
+      padding: 0;
+      text-decoration: underline;
+    }
+    form.inline {
+      display: inline;
+    }
+    label {
+      display: block;
+      margin-bottom: 0.9rem;
+      font-size: 0.95rem;
+    }
+    label span {
+      display: block;
+      margin-bottom: 0.35rem;
+      font-weight: 600;
+    }
+    input[type="text"],
+    input[type="email"],
+    input[type="password"] {
+      width: 100%;
+      border: 1px solid #cbd5f5;
+      border-radius: 0.5rem;
+      padding: 0.55rem 0.75rem;
+      font-size: 1rem;
+    }
+    input[type="checkbox"] {
+      margin-right: 0.4rem;
+    }
+    .feedback {
+      border-radius: 0.6rem;
+      padding: 0.85rem 1rem;
+      margin-bottom: 1rem;
+    }
+    .feedback.error {
+      background: #fee2e2;
+      border: 1px solid #fecaca;
+      color: #991b1b;
+    }
+    .feedback.success {
+      background: #dcfce7;
+      border: 1px solid #bbf7d0;
+      color: #166534;
+    }
+  </style>
+</head>
+<body>
+<header>
+  <nav>
+    <a href="/admin/login">Вход</a>
+    <a href="/admin/users">Пользователи</a>
+  </nav>
+</header>
+<main>
+  {% if errors %}
+    <div class="feedback error">
+      <ul>
+        {% for error in errors %}
+          <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  {% if message %}
+    <div class="feedback success">{{ message }}</div>
+  {% endif %}
+  {% block content %}{% endblock %}
+</main>
+</body>
+</html>

--- a/app/templates/admin/login.html
+++ b/app/templates/admin/login.html
@@ -1,0 +1,61 @@
+{% extends "admin/base.html" %}
+{% block title %}Вход администратора{% endblock %}
+{% block content %}
+<div class="card">
+  <h1>Вход администратора</h1>
+  <p>Укажите логин и пароль администратора, чтобы получить доступ к управлению пользователями.</p>
+  <form id="login-form">
+    <label>
+      <span>Логин</span>
+      <input type="text" name="username" autocomplete="username" required>
+    </label>
+    <label>
+      <span>Пароль</span>
+      <input type="password" name="password" autocomplete="current-password" required>
+    </label>
+    <button type="submit" class="button primary">Войти</button>
+  </form>
+  <div id="login-error" class="feedback error" style="display:none;"></div>
+</div>
+<script>
+  const form = document.getElementById("login-form");
+  const errorBox = document.getElementById("login-error");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    errorBox.style.display = "none";
+    const formData = new FormData(form);
+    const username = formData.get("username");
+    const password = formData.get("password");
+    const token = btoa(`${username}:${password}`);
+
+    try {
+      const response = await fetch("/admin/login", {
+        method: "POST",
+        headers: { "Authorization": `Basic ${token}` },
+        credentials: "include"
+      });
+
+      if (response.ok) {
+        window.location.href = "/admin/users";
+        return;
+      }
+
+      let message = "Не удалось выполнить вход.";
+      try {
+        const payload = await response.json();
+        if (payload.detail) {
+          message = payload.detail;
+        }
+      } catch (error) {
+        console.error(error);
+      }
+      errorBox.textContent = message;
+      errorBox.style.display = "block";
+    } catch (error) {
+      errorBox.textContent = "Ошибка сети. Попробуйте ещё раз.";
+      errorBox.style.display = "block";
+    }
+  });
+</script>
+{% endblock %}

--- a/app/templates/admin/user_form.html
+++ b/app/templates/admin/user_form.html
@@ -1,0 +1,56 @@
+{% extends "admin/base.html" %}
+{% block title %}Редактирование пользователя{% endblock %}
+{% block content %}
+{% set current = form_data or user %}
+<div class="card">
+  <h1>Редактирование пользователя</h1>
+  <form method="post" action="/admin/users/{{ user.id }}">
+    <label>
+      <span>Имя</span>
+      <input type="text" name="first_name" value="{{ current.first_name or '' }}" required>
+    </label>
+    <label>
+      <span>Фамилия</span>
+      <input type="text" name="last_name" value="{{ current.last_name or '' }}" required>
+    </label>
+    <label>
+      <span>Логин</span>
+      <input type="text" name="username" value="{{ current.username }}" required>
+    </label>
+    <label>
+      <span>Email</span>
+      <input type="email" name="email" value="{{ current.email }}" required>
+    </label>
+    <label>
+      <span>Новый пароль</span>
+      <input type="password" name="password" placeholder="Оставьте пустым, чтобы не менять">
+    </label>
+    <label>
+      <input type="checkbox" name="is_active" value="true" {% if current.is_active %}checked{% endif %}>
+      Активен
+    </label>
+    <label>
+      <input type="checkbox" name="is_admin" value="true" {% if current.is_admin %}checked{% endif %}>
+      Администратор
+    </label>
+    <label>
+      <input type="checkbox" name="is_supplier" value="true" {% if current.is_supplier %}checked{% endif %}>
+      Поставщик
+    </label>
+    <label>
+      <input type="checkbox" name="is_customer" value="true" {% if current.is_customer %}checked{% endif %}>
+      Покупатель
+    </label>
+    <button type="submit" class="button primary">Сохранить</button>
+    <a class="button secondary" href="/admin/users">Отмена</a>
+  </form>
+</div>
+
+<div class="card">
+  <h2>Удаление</h2>
+  <p>Удаление пользователя необратимо. Убедитесь, что хотите продолжить.</p>
+  <form method="post" action="/admin/users/{{ user.id }}/delete">
+    <button type="submit" class="button danger" onclick="return confirm('Удалить пользователя {{ user.username }}?');">Удалить</button>
+  </form>
+</div>
+{% endblock %}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -1,0 +1,95 @@
+{% extends "admin/base.html" %}
+{% block title %}Пользователи{% endblock %}
+{% block content %}
+<div class="card">
+  <h1>Пользователи</h1>
+  <p>Добавляйте новых пользователей и управляйте существующими через формы ниже.</p>
+</div>
+
+<div class="card">
+  <h2>Добавить пользователя</h2>
+  <form method="post" action="/admin/users">
+    <label>
+      <span>Имя</span>
+      <input type="text" name="first_name" value="{{ form_data.first_name if form_data else '' }}" required>
+    </label>
+    <label>
+      <span>Фамилия</span>
+      <input type="text" name="last_name" value="{{ form_data.last_name if form_data else '' }}" required>
+    </label>
+    <label>
+      <span>Логин</span>
+      <input type="text" name="username" value="{{ form_data.username if form_data else '' }}" required>
+    </label>
+    <label>
+      <span>Email</span>
+      <input type="email" name="email" value="{{ form_data.email if form_data else '' }}" required>
+    </label>
+    <label>
+      <span>Пароль</span>
+      <input type="password" name="password" required>
+    </label>
+    <label>
+      <input type="checkbox" name="is_active" value="true" {% if form_data is none or form_data.is_active %}checked{% endif %}>
+      Активен
+    </label>
+    <label>
+      <input type="checkbox" name="is_admin" value="true" {% if form_data and form_data.is_admin %}checked{% endif %}>
+      Администратор
+    </label>
+    <label>
+      <input type="checkbox" name="is_supplier" value="true" {% if form_data and form_data.is_supplier %}checked{% endif %}>
+      Поставщик
+    </label>
+    <label>
+      <input type="checkbox" name="is_customer" value="true" {% if form_data is none or form_data.is_customer %}checked{% endif %}>
+      Покупатель
+    </label>
+    <button type="submit" class="button primary">Создать</button>
+  </form>
+</div>
+
+<div class="card">
+  <h2>Список пользователей</h2>
+  {% if users %}
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Имя</th>
+          <th>Фамилия</th>
+          <th>Логин</th>
+          <th>Email</th>
+          <th>Статусы</th>
+          <th>Действия</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for user in users %}
+        <tr>
+          <td>{{ user.id }}</td>
+          <td>{{ user.first_name or "—" }}</td>
+          <td>{{ user.last_name or "—" }}</td>
+          <td>{{ user.username }}</td>
+          <td>{{ user.email }}</td>
+          <td>
+            <div>Активен: {{ "да" if user.is_active else "нет" }}</div>
+            <div>Админ: {{ "да" if user.is_admin else "нет" }}</div>
+            <div>Поставщик: {{ "да" if user.is_supplier else "нет" }}</div>
+            <div>Покупатель: {{ "да" if user.is_customer else "нет" }}</div>
+          </td>
+          <td>
+            <a class="button link" href="/admin/users/{{ user.id }}/edit">Редактировать</a>
+            <form class="inline" method="post" action="/admin/users/{{ user.id }}/delete">
+              <button type="submit" class="button danger" onclick="return confirm('Удалить пользователя {{ user.username }}?');">Удалить</button>
+            </form>
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p>Пользователи не найдены.</p>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace the FastAdmin mount with a built-in admin router registered on `/admin`
- implement HTTP Basic protected CRUD views for the `User` model using async SQLAlchemy and Pydantic validation
- add Jinja2 templates for login, listing, creation, and editing flows in the custom admin UI

## Testing
- not run (DATABASE_URL environment variable not configured in CI container)


------
https://chatgpt.com/codex/tasks/task_e_68e1479ed70c8320a81524e70ad0c536